### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,5 @@ jobs:
         export CREATE_EVENT_REF_TYPE=$(jq --raw-output .ref_type "$GITHUB_EVENT_PATH")
         export TAGNAME=$(jq --raw-output .ref "$GITHUB_EVENT_PATH")
         # install ghr, then upload archve.
-        go get -u github.com/tcnksm/ghr
+        go install -u github.com/tcnksm/ghr
         ${GOPATH}/bin/ghr -b "${PACKAGE_NAME} ${TAGNAME}" -replace ${TAGNAME} ${PACKAGE_NAME}.zip


### PR DESCRIPTION
goglang versioin 18 対応のため、go get ではなく、go install を使う http://psychedelicnekopunch.com/archives/2780